### PR TITLE
fix(filters): Gift Count Associated Event ID (#3064)

### DIFF
--- a/src/backend/events/filters/builtin/twitch/gift-count.ts
+++ b/src/backend/events/filters/builtin/twitch/gift-count.ts
@@ -6,7 +6,7 @@ const filter = createNumberFilter({
     description: "Filter by the number of subs gifted",
     eventMetaKey: "subCount",
     events: [
-        { eventSourceId: "twitch", eventId: "subs-gifted" }
+        { eventSourceId: "twitch", eventId: "community-subs-gifted" }
     ]
 });
 


### PR DESCRIPTION
- It got bumped to the wrong event id by mistake. Fix that.

#3064